### PR TITLE
Clarify CUDA 12 and TensorRT requirements in README and playgroground and update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 files: ""
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v5.0.0
     hooks:
       - id: check-ast
       - id: check-toml
@@ -47,6 +47,6 @@ repos:
     hooks:
       - id: nbstripout
   - repo: https://github.com/hadialqattan/pycln # remove unused import
-    rev: v2.3.0
+    rev: v2.4.0
     hooks:
       - id: pycln

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 ## Requirements
 
+### CUDA 12
+
 For **local inference**, ensure that you have CUDA 12 and cuDNN 9 installed, as they are required for onnxruntime version 1.20.1.
 
 To install cuDNN 9:
@@ -26,7 +28,13 @@ To install cuDNN 9:
 apt-get -y install cudnn9-cuda-12
 ```
 
+### (Optional) TensorRT
+
 To perform inference using TensorRT, ensure you have TensorRT version 10.5 installed.
+
+```bash
+sudo apt-get install tensorrt
+```
 
 # Install
 

--- a/notebooks/playground.ipynb
+++ b/notebooks/playground.ipynb
@@ -80,6 +80,69 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Available Runtime Types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from focoos.ports import RuntimeTypes\n",
+    "\n",
+    "for runtime_type in RuntimeTypes:\n",
+    "    print(runtime_type)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### OnnxRuntime With CUDA (focoos_object365)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import os\n",
+    "from pprint import pprint\n",
+    "from supervision import plot_image\n",
+    "\n",
+    "focoos = Focoos(\n",
+    "    api_key=os.getenv(\"FOCOOS_API_KEY\"),\n",
+    ")\n",
+    "image_path = \"./assets/ade_val_034.jpg\"\n",
+    "model_ref = \"focoos_object365\"\n",
+    "\n",
+    "\n",
+    "model = focoos.get_local_model(model_ref)\n",
+    "\n",
+    "latency = model.benchmark(iterations=10, size=640)\n",
+    "pprint(latency)\n",
+    "# pprint(latency)\n",
+    "output, preview = model.infer(image_path, threshold=0.3, annotate=True)\n",
+    "pprint(output.detections)\n",
+    "pprint(output.latency)\n",
+    "\n",
+    "plot_image(preview)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### OnnxRuntime With TensorRT (FP16) (focoos_object365)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -87,23 +150,21 @@
    "source": [
     "import os\n",
     "\n",
-    "# os.environ[\"RUNTIME_TYPE\"] = \"onnx_trt16\"\n",
-    "from focoos import Focoos, DEV_API_URL\n",
-    "from focoos.config import FOCOOS_CONFIG\n",
+    "from focoos import Focoos\n",
     "import os\n",
     "from pprint import pprint\n",
     "from supervision import plot_image\n",
     "\n",
-    "print(FOCOOS_CONFIG)\n",
+    "from focoos.ports import RuntimeTypes\n",
+    "\n",
     "focoos = Focoos(\n",
     "    api_key=os.getenv(\"FOCOOS_API_KEY\"),\n",
-    "    host_url=DEV_API_URL,\n",
     ")\n",
     "image_path = \"./assets/ade_val_034.jpg\"\n",
-    "model_ref = \"focoos_rtdetr\"\n",
+    "model_ref = \"focoos_object365\"\n",
     "\n",
     "\n",
-    "model = focoos.get_local_model(model_ref)\n",
+    "model = focoos.get_local_model(model_ref, runtime_type=RuntimeTypes.ONNX_TRT16)\n",
     "\n",
     "latency = model.benchmark(iterations=10, size=640)\n",
     "pprint(latency)\n",


### PR DESCRIPTION
### PR Summary

#### TITLE
Update pre-commit hooks and enhance README with CUDA and TensorRT instructions

#### CONTEXT
This PR was created to update the pre-commit hooks to their latest versions and to provide clearer instructions for setting up CUDA and TensorRT, which are essential for local inference using onnxruntime. The changes aim to improve the development workflow and ensure that users have the necessary environment setup for optimal performance.

#### KEY CHANGES
- Updated `.pre-commit-config.yaml` to use newer versions of pre-commit hooks.
- Enhanced `README.md` with detailed instructions for installing CUDA 12 and TensorRT.
- Added new sections in `notebooks/playground.ipynb` to demonstrate available runtime types and usage of OnnxRuntime with CUDA and TensorRT.

#### IMPACT
- The updates to the pre-commit hooks may affect the development workflow by enforcing new checks or rules.
- The README changes provide clearer guidance for users setting up their local environment, potentially reducing setup errors.
- The notebook changes offer additional examples and documentation for using different runtime types, which can aid in model deployment and inference.

#### TECHNICAL DETAILS
- **Pre-commit Hooks**: Updated versions in `.pre-commit-config.yaml` to ensure compatibility and leverage new features or fixes.
  ```yaml
  - repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v5.0.0
  - repo: https://github.com/hadialqattan/pycln
    rev: v2.4.0
  ```
- **CUDA and TensorRT**: Added installation instructions in `README.md` to guide users through setting up the necessary dependencies for onnxruntime.
  ```markdown
  ### CUDA 12
  apt-get -y install cudnn9-cuda-12

  ### (Optional) TensorRT
  sudo apt-get install tensorrt
  ```
- **Notebook Enhancements**: Added markdown and code cells in `notebooks/playground.ipynb` to illustrate the use of different runtime types and configurations.
  ```python
  from focoos.ports import RuntimeTypes
  for runtime_type in RuntimeTypes:
      print(runtime_type)
  ```