### PR TITLE
hotfix(ci): remove double "v"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           dry_run: false
           custom_tag: ${{ steps.get_next_version.outputs.new_tag }}
+          tag_prefix: ""
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
## TITLE
Remove Tag Prefix in Release Workflow

## CONTEXT
This PR was created to address the issue of unnecessary tag prefixes in the release workflow, which could lead to confusion and inconsistency in versioning.

## KEY CHANGES
- Modified the `.github/workflows/release.yml` file to set the `tag_prefix` to an empty string, ensuring that tags are created without any prefix.

## IMPACT
This change simplifies the versioning process by removing unnecessary prefixes from tags, leading to clearer and more consistent release management.

## TECHNICAL DETAILS

### Release Workflow
The `tag_prefix` parameter in the release workflow has been set to an empty string, which ensures that new tags are created without any additional prefixes. This change is reflected in the following snippet:

```yaml
- name: Tag the release
  uses: anothrNick/github-tag-action@v1.36.0
  with:
    github_token: ${{ secrets.GITHUB_TOKEN }}
    dry_run: false
    custom_tag: ${{ steps.get_next_version.outputs.new_tag }}
    tag_prefix: ""
```