### PR TITLE
fix: restore scale detections

### DIFF
--- a/focoos/utils/vision.py
+++ b/focoos/utils/vision.py
@@ -80,9 +80,11 @@ def image_preprocess(
         im1, im0 = image_preprocess("image.jpg", resize=256)
     """
     im0 = image_loader(im)
+    _im1 = im0
     if resize:
-        im0 = cv2.resize(im0, (resize, resize))
-    im1 = np.ascontiguousarray(im0.transpose(2, 0, 1)[np.newaxis, :]).astype(
+        _im1 = cv2.resize(im0, (resize, resize))
+
+    im1 = np.ascontiguousarray(_im1.transpose(2, 0, 1)[np.newaxis, :]).astype(
         dtype
     )  # HWC->1CHW
     return im1, im0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def mock_http_client():
 @pytest.fixture
 def pil_image() -> Image.Image:
     """Create a simple RGB image using PIL."""
-    image = Image.new("RGB", (100, 100), color="red")
+    image = Image.new("RGB", (640, 640), color="red")
     return image
 
 

--- a/tests/utils/test_vision.py
+++ b/tests/utils/test_vision.py
@@ -34,25 +34,25 @@ def test_class_to_index():
 def test_image_loader_pil_image(pil_image):
     image = image_loader(pil_image)
     assert isinstance(image, np.ndarray)
-    assert image.shape == (100, 100, 3)
+    assert image.shape == (640, 640, 3)
 
 
 def test_image_loader_image_bytes(image_bytes):
     image = image_loader(image_bytes)
     assert isinstance(image, np.ndarray)
-    assert image.shape == (100, 100, 3)
+    assert image.shape == (640, 640, 3)
 
 
 def test_image_loader_image_path(image_path):
     image = image_loader(image_path)
     assert isinstance(image, np.ndarray)
-    assert image.shape == (100, 100, 3)
+    assert image.shape == (640, 640, 3)
 
 
 def test_image_loader_image_ndarray(image_ndarray):
     image = image_loader(image_ndarray)
     assert isinstance(image, np.ndarray)
-    assert image.shape == (100, 100, 3)
+    assert image.shape == (640, 640, 3)
 
 
 def test_image_preprocess_resize(pil_image):
@@ -63,10 +63,10 @@ def test_image_preprocess_resize(pil_image):
 
     # Ensure the resized image shape matches (100, 100, 3)
     assert im0.shape == (
-        resize_dim,
-        resize_dim,
+        pil_image.height,
+        pil_image.width,
         3,
-    ), f"Expected shape {(resize_dim, resize_dim, 3)}, but got {im0.shape}"
+    ), f"Expected shape {(pil_image.height, pil_image.width, 3)}, but got {im0.shape}"
 
     # Ensure that im1 has shape (1, 3, 100, 100) after processing
     assert im1.shape == (
@@ -106,7 +106,7 @@ def test_base64mask_to_mask(image_bytes):
     # Verify the result is a NumPy array
     assert isinstance(result, np.ndarray), "Result should be a NumPy array"
     # Verify the shape matches the original image
-    assert result.shape == (100, 100, 3), "Decoded image shape is incorrect"
+    assert result.shape == (640, 640, 3), "Decoded image shape is incorrect"
 
 
 def test_focoos_detections_to_supervision_bbox(focoos_detections_bbox):


### PR DESCRIPTION
Scale detections to original (im0) size are broken due to typo on im0 and im1.

## CONTEXT
This PR addresses the need for consistent image dimensions in tests and improves the image preprocessing logic for better clarity and maintainability.

## KEY CHANGES
- Refactored `image_preprocess` function to handle resizing more clearly.
- Updated test image dimensions from 100x100 to 640x640 for better alignment with real-world scenarios.
- Adjusted assertions in tests to reflect the new image dimensions.

## IMPACT
These changes ensure that the image processing logic is more intuitive and that tests are aligned with realistic image sizes, improving test reliability and code clarity.