### PR TITLE
fix: separate postprocessing from runtime inference logic and handle null masks results

### DIFF
--- a/focoos/remote_model.py
+++ b/focoos/remote_model.py
@@ -291,10 +291,12 @@ class RemoteModel:
         )
         t1 = time.time()
         if res.status_code == 200:
-            logger.debug(f"Inference time: {t1 - t0:.3f} seconds")
             detections = FocoosDetections(
                 detections=[FocoosDet.from_json(d) for d in res.json().get("detections", [])],
                 latency=res.json().get("latency", None),
+            )
+            logger.debug(
+                f"Found {len(detections.detections)} detections. Inference Request time: {(t1 - t0) * 1000:.0f}ms"
             )
             preview = None
             if annotate:

--- a/focoos/remote_model.py
+++ b/focoos/remote_model.py
@@ -224,6 +224,10 @@ class RemoteModel:
         Returns:
             np.ndarray: The annotated image as a NumPy array.
         """
+
+        if len(detections.xyxy) == 0:
+            logger.warning("No detections found, skipping annotation")
+            return im
         classes = self.metadata.classes
         if classes is not None:
             labels = [

--- a/focoos/runtime.py
+++ b/focoos/runtime.py
@@ -20,11 +20,9 @@ Classes:
 from abc import abstractmethod
 from pathlib import Path
 from time import perf_counter
-from typing import Any, List, Tuple
+from typing import Any
 
 import numpy as np
-
-from focoos.utils.vision import mask_to_xyxy
 
 try:
     import torch
@@ -40,11 +38,9 @@ try:
 except ImportError:
     ORT_AVAILABLE = False
 
-import supervision as sv
 
 # from supervision.detection.utils import mask_to_xyxy
 from focoos.ports import (
-    FocoosTask,
     LatencyMetrics,
     ModelMetadata,
     OnnxRuntimeOpts,
@@ -59,93 +55,12 @@ GPU_ID = 0
 logger = get_logger()
 
 
-def get_postprocess_fn(task: FocoosTask):
-    if task == FocoosTask.INSTANCE_SEGMENTATION:
-        return instance_postprocess
-    elif task == FocoosTask.SEMSEG:
-        return semseg_postprocess
-    else:
-        return det_postprocess
-
-
-def det_postprocess(out: List[np.ndarray], im0_shape: Tuple[int, int], conf_threshold: float) -> sv.Detections:
-    """
-    Postprocesses the output of an object detection model and filters detections
-    based on a confidence threshold.
-
-    Args:
-        out (List[np.ndarray]): The output of the detection model.
-        im0_shape (Tuple[int, int]): The original shape of the input image (height, width).
-        conf_threshold (float): The confidence threshold for filtering detections.
-
-    Returns:
-        sv.Detections: A sv.Detections object containing the filtered bounding boxes, class ids, and confidences.
-    """
-    cls_ids, boxes, confs = out
-    boxes[:, 0::2] *= im0_shape[1]
-    boxes[:, 1::2] *= im0_shape[0]
-    high_conf_indices = (confs > conf_threshold).nonzero()
-
-    return sv.Detections(
-        xyxy=boxes[high_conf_indices].astype(int),
-        class_id=cls_ids[high_conf_indices].astype(int),
-        confidence=confs[high_conf_indices].astype(float),
-    )
-
-
-def semseg_postprocess(out: List[np.ndarray], im0_shape: Tuple[int, int], conf_threshold: float) -> sv.Detections:
-    """
-    Postprocesses the output of a semantic segmentation model and filters based
-    on a confidence threshold.
-
-    Args:
-        out (List[np.ndarray]): The output of the semantic segmentation model.
-        conf_threshold (float): The confidence threshold for filtering detections.
-
-    Returns:
-        sv.Detections: A sv.Detections object containing the masks, class ids, and confidences.
-    """
-    cls_ids, mask, confs = out[0][0], out[1][0], out[2][0]
-    masks = np.equal(mask, np.arange(len(cls_ids))[:, None, None])
-    high_conf_indices = np.where(confs > conf_threshold)[0]
-    masks = masks[high_conf_indices].astype(bool)
-    cls_ids = cls_ids[high_conf_indices].astype(int)
-    confs = confs[high_conf_indices].astype(float)
-    xyxy = mask_to_xyxy(masks)
-    return sv.Detections(
-        mask=masks,
-        xyxy=xyxy,
-        class_id=cls_ids,
-        confidence=confs,
-    )
-
-
-def instance_postprocess(out: List[np.ndarray], im0_shape: Tuple[int, int], conf_threshold: float) -> sv.Detections:
-    """
-    Postprocesses the output of an instance segmentation model and filters detections
-    based on a confidence threshold.
-    """
-    cls_ids, mask, confs = out[0][0], out[1][0], out[2][0]
-    high_conf_indices = np.where(confs > conf_threshold)[0]
-
-    masks = mask[high_conf_indices].astype(bool)
-    cls_ids = cls_ids[high_conf_indices].astype(int)
-    confs = confs[high_conf_indices].astype(float)
-    xyxy = mask_to_xyxy(masks)
-    return sv.Detections(
-        mask=masks,
-        xyxy=xyxy,
-        class_id=cls_ids,
-        confidence=confs,
-    )
-
-
 class BaseRuntime:
     def __init__(self, model_path: str, opts: Any, model_metadata: ModelMetadata):
         pass
 
     @abstractmethod
-    def __call__(self, im: np.ndarray, conf_threshold: float) -> sv.Detections:
+    def __call__(self, im: np.ndarray) -> np.ndarray:
         pass
 
     @abstractmethod
@@ -168,8 +83,6 @@ class ONNXRuntime(BaseRuntime):
         self.name = Path(model_path).stem
         self.opts = opts
         self.model_metadata = model_metadata
-
-        self.postprocess_fn = get_postprocess_fn(model_metadata.task)
 
         # Setup session options
         options = ort.SessionOptions()
@@ -241,12 +154,12 @@ class ONNXRuntime(BaseRuntime):
 
         self.logger.info("⏱️ [onnxruntime] Warmup done")
 
-    def __call__(self, im: np.ndarray, conf_threshold: float) -> sv.Detections:
+    def __call__(self, im: np.ndarray) -> list[np.ndarray]:
         """Run inference and return detections."""
         input_name = self.ort_sess.get_inputs()[0].name
         out_name = [output.name for output in self.ort_sess.get_outputs()]
         out = self.ort_sess.run(out_name, {input_name: im})
-        return self.postprocess_fn(out=out, im0_shape=(im.shape[2], im.shape[3]), conf_threshold=conf_threshold)
+        return out
 
     def benchmark(self, iterations=20, size=640) -> LatencyMetrics:
         """Benchmark model latency."""
@@ -297,7 +210,6 @@ class TorchscriptRuntime(BaseRuntime):
         self.logger = get_logger(name="TorchscriptEngine")
         self.logger.info(f"🔧 [torchscript] Device: {self.device}")
         self.opts = opts
-        self.postprocess_fn = get_postprocess_fn(model_metadata.task)
 
         map_location = None if torch.cuda.is_available() else "cpu"
 
@@ -312,12 +224,12 @@ class TorchscriptRuntime(BaseRuntime):
                     self.model(np_image)
             self.logger.info("⏱️ [torchscript] WARMUP DONE")
 
-    def __call__(self, im: np.ndarray, conf_threshold: float) -> sv.Detections:
+    def __call__(self, im: np.ndarray) -> list[np.ndarray]:
         """Run inference and return detections."""
         with torch.no_grad():
             torch_image = torch.from_numpy(im).to(self.device, dtype=torch.float32)
             res = self.model(torch_image)
-            return self.postprocess_fn([r.cpu().numpy() for r in res], (im.shape[2], im.shape[3]), conf_threshold)
+            return [r.cpu().numpy() for r in res]
 
     def benchmark(self, iterations=20, size=640) -> LatencyMetrics:
         """Benchmark model latency."""

--- a/focoos/utils/vision.py
+++ b/focoos/utils/vision.py
@@ -147,7 +147,7 @@ def fai_detections_to_sv(inference_output: FocoosDetections, im0_shape: tuple) -
     class_id = np.array([d.cls_id for d in inference_output.detections])
     confidence = np.array([d.conf for d in inference_output.detections])
     if xyxy.shape[0] == 0:
-        xyxy = np.empty((0, 4))
+        xyxy = np.zeros((0, 4))
     _masks = []
     if len(inference_output.detections) > 0 and inference_output.detections[0].mask:
         _masks = [np.zeros(im0_shape, dtype=bool) for _ in inference_output.detections]
@@ -228,8 +228,8 @@ def sv_to_fai_detections(detections: sv.Detections, classes: Optional[list[str]]
             x1, y1, x2, y2 = map(int, xyxy)
             x1 = max(x1 - 1, 0)
             y1 = max(y1 - 1, 0)
-            x2 = min(x2 + 1, mask.shape[1])
-            y2 = min(y2 + 1, mask.shape[0])
+            x2 = min(x2 + 2, mask.shape[1])
+            y2 = min(y2 + 2, mask.shape[0])
             cropped_mask = mask[y1:y2, x1:x2]
             mask = binary_mask_to_base64(cropped_mask)
 
@@ -258,7 +258,7 @@ def masks_to_xyxy(masks: np.ndarray) -> np.ndarray:
     """
     # Vectorized approach to find bounding boxes
     n = masks.shape[0]
-    xyxy = np.empty((n, 4), dtype=int)
+    xyxy = np.zeros((n, 4), dtype=int)
 
     # Use np.any to quickly find rows and columns with True values
     for i, mask in enumerate(masks):
@@ -329,7 +329,7 @@ def semseg_postprocess(out: List[np.ndarray], im0_shape: Tuple[int, int], conf_t
     if len(masks.shape) != 3:
         return sv.Detections(
             mask=None,
-            xyxy=np.empty((0, 4)),
+            xyxy=np.zeros((0, 4)),
             class_id=None,
             confidence=None,
         )
@@ -361,7 +361,7 @@ def instance_postprocess(out: List[np.ndarray], im0_shape: Tuple[int, int], conf
     if len(masks.shape) != 3:
         return sv.Detections(
             mask=None,
-            xyxy=np.empty((0, 4)),
+            xyxy=np.zeros((0, 4)),
             class_id=None,
             confidence=None,
         )

--- a/tests/test_local_model.py
+++ b/tests/test_local_model.py
@@ -139,6 +139,11 @@ def mock_sv_detections() -> sv.Detections:
     )
 
 
+@pytest.fixture
+def mock_runtime_detections() -> list[np.ndarray]:
+    return [np.array([[2, 8, 16, 32], [4, 10, 18, 34]]), np.array([0, 1]), np.array([0.8, 0.9])]
+
+
 def test_annotate_detection_metadata_classes_none(
     image_ndarray: np.ndarray, mock_local_model_onnx: LocalModel, mock_sv_detections
 ):
@@ -175,6 +180,7 @@ def mock_infer_setup(
     mock_local_model: LocalModel,
     image_ndarray: np.ndarray,
     mock_sv_detections: sv.Detections,
+    mock_runtime_detections: list[np.ndarray],
     mock_focoos_detections: FocoosDetections,
     annotate: bool,
 ):
@@ -191,6 +197,10 @@ def mock_infer_setup(
     mock_sv_to_focoos_detections = mocker.patch("focoos.local_model.sv_to_fai_detections")
     mock_sv_to_focoos_detections.return_value = mock_focoos_detections.detections
 
+    # mock postprocess
+    mock_postprocess = mocker.patch.object(mock_local_model, "postprocess_fn")
+    mock_postprocess.return_value = mock_sv_detections
+
     # Mock _annotate
     mock_annotate = mocker.patch.object(mock_local_model, "_annotate", autospec=True)
     if annotate:
@@ -201,9 +211,9 @@ def mock_infer_setup(
     # Mock runtime
     class MockRuntime(MagicMock):
         def __call__(self, *args, **kwargs):
-            return mock_sv_detections
+            return mock_runtime_detections
 
-    mock_runtime_call = mocker.patch.object(MockRuntime, "__call__", return_value=mock_sv_detections)
+    mock_runtime_call = mocker.patch.object(MockRuntime, "__call__", return_value=mock_runtime_detections)
     mock_local_model.runtime = MockRuntime(spec=ONNXRuntime)
 
     return (
@@ -222,6 +232,7 @@ def test_infer_onnx(
     image_ndarray,
     mock_sv_detections,
     mock_focoos_detections,
+    mock_runtime_detections,
     annotate,
 ):
     # Arrange
@@ -230,6 +241,7 @@ def test_infer_onnx(
         mock_local_model_onnx,
         image_ndarray,
         mock_sv_detections,
+        mock_runtime_detections,
         mock_focoos_detections,
         annotate,
     )

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,22 +1,16 @@
 import pathlib
 from unittest.mock import MagicMock
 
-import numpy as np
 import pytest
-import supervision as sv
 from pytest_mock import MockerFixture
 
-from focoos.ports import FocoosTask, ModelMetadata, OnnxRuntimeOpts, RuntimeTypes, TorchscriptRuntimeOpts
+from focoos.ports import ModelMetadata, OnnxRuntimeOpts, RuntimeTypes, TorchscriptRuntimeOpts
 from focoos.runtime import (
     ORT_AVAILABLE,
     TORCH_AVAILABLE,
     ONNXRuntime,
     TorchscriptRuntime,
-    det_postprocess,
-    get_postprocess_fn,
-    instance_postprocess,
     load_runtime,
-    semseg_postprocess,
 )
 
 
@@ -54,70 +48,6 @@ def test_onnx_import():
     import onnxruntime as ort
 
     assert ort is not None, "ONNX Runtime should be properly imported"
-
-
-def test_det_post_process():
-    cls_ids = np.array([1, 2, 3])
-    boxes = np.array([[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8], [0.9, 1.0, 1.1, 1.2]])
-    confs = np.array([0.8, 0.9, 0.7])
-    out = [cls_ids, boxes, confs]
-
-    im0_shape = (640, 480)
-    conf_threshold = 0.75
-    sv_detections = det_postprocess(out, im0_shape, conf_threshold)
-
-    np.testing.assert_array_equal(sv_detections.xyxy, np.array([[48, 128, 144, 256], [240, 384, 336, 512]]))
-    assert sv_detections.class_id is not None
-    np.testing.assert_array_equal(sv_detections.class_id, np.array([1, 2]))
-    assert sv_detections.confidence is not None
-    np.testing.assert_array_equal(sv_detections.confidence, np.array([0.8, 0.9]))
-
-
-def test_semseg_postprocess():
-    cls_ids = np.array([1, 2, 3])
-    mask = np.array(
-        [
-            [0, 1, 1, 2],
-            [0, 1, 2, 2],
-            [0, 0, 1, 2],
-        ]
-    )
-    confs = np.array([0.7, 0.9, 0.8])
-    out = [
-        np.expand_dims(cls_ids, axis=0),
-        np.expand_dims(mask, axis=0),
-        np.expand_dims(confs, axis=0),
-    ]
-
-    im0_shape = (3, 4)
-    conf_threshold = 0.75
-
-    sv_detections = semseg_postprocess(out, im0_shape, conf_threshold)
-
-    # Expected masks
-    expected_masks = np.array(
-        [
-            [
-                [False, True, True, False],
-                [False, True, False, False],
-                [False, False, True, False],
-            ],  # Class 1
-            [
-                [False, False, False, True],
-                [False, False, True, True],
-                [False, False, False, True],
-            ],  # Class 2
-        ]
-    )
-
-    # Assertions
-    assert sv_detections.mask is not None
-    np.testing.assert_array_equal(sv_detections.mask, expected_masks)
-    assert sv_detections.class_id is not None
-    np.testing.assert_array_equal(sv_detections.class_id, np.array([2, 3]))
-    assert sv_detections.confidence is not None
-    np.testing.assert_array_equal(sv_detections.confidence, np.array([0.9, 0.8]))
-    assert sv_detections.xyxy.shape == (2, 4)
 
 
 @pytest.mark.parametrize(
@@ -235,59 +165,3 @@ def test_load_unavailable_runtime(mocker: MockerFixture):
         load_runtime(RuntimeTypes.TORCHSCRIPT_32, "fake_model_path", MagicMock(spec=ModelMetadata), 2)
     with pytest.raises(ImportError):
         load_runtime(RuntimeTypes.ONNX_CUDA32, "fake_model_path", MagicMock(spec=ModelMetadata), 2)
-
-
-def test_get_postprocess_fn():
-    """
-    Test the get_postprocess_fn function to ensure it returns
-    the correct postprocessing function for each task.
-    """
-    # Test detection task
-    det_fn = get_postprocess_fn(FocoosTask.DETECTION)
-    assert det_fn == det_postprocess, "Detection task should return det_postprocess function"
-
-    # Test instance segmentation task
-    instance_fn = get_postprocess_fn(FocoosTask.INSTANCE_SEGMENTATION)
-    assert instance_fn == instance_postprocess, "Instance segmentation task should return instance_postprocess function"
-
-    # Test semantic segmentation task
-    semseg_fn = get_postprocess_fn(FocoosTask.SEMSEG)
-    assert semseg_fn == semseg_postprocess, "Semantic segmentation task should return semseg_postprocess function"
-
-    # Test all FocoosTask values to ensure no exceptions
-    for task in FocoosTask:
-        fn = get_postprocess_fn(task)
-        assert callable(fn), f"Postprocess function for {task} should be callable"
-
-
-def test_instance_postprocess():
-    """Test instance segmentation postprocessing"""
-    cls_ids = np.array([0, 1])
-    masks = np.zeros((2, 100, 100))
-    masks[0, 10:30, 10:30] = 1
-    masks[1, 40:60, 40:60] = 1
-    confs = np.array([0.95, 0.85])
-    out = [[cls_ids], [masks], [confs]]
-
-    result = instance_postprocess(out, (100, 100), 0.8)
-
-    assert isinstance(result, sv.Detections)
-    assert len(result) == 2
-    assert result.mask is not None
-    assert result.xyxy is not None
-    assert result.class_id is not None
-    assert result.confidence is not None
-
-
-def test_confidence_threshold_filtering():
-    """Test that confidence threshold filtering works correctly"""
-    out = [
-        np.array([0, 1, 2]),  # cls_ids
-        np.array([[0.1, 0.1, 0.3, 0.3], [0.4, 0.4, 0.6, 0.6], [0.7, 0.7, 0.9, 0.9]]),  # boxes
-        np.array([0.95, 0.55, 0.85]),  # confs
-    ]
-
-    result = det_postprocess(out, (100, 100), conf_threshold=0.8)
-
-    assert len(result) == 2  # Should only keep detections with conf > 0.8
-    assert all(conf > 0.8 for conf in result.confidence)

--- a/tests/utils/test_vision.py
+++ b/tests/utils/test_vision.py
@@ -4,18 +4,22 @@ import math
 import numpy as np
 import supervision as sv
 
-from focoos.ports import FocoosDet
+from focoos.ports import FocoosDet, FocoosTask
 from focoos.utils.vision import (
     base64mask_to_mask,
     binary_mask_to_base64,
     class_to_index,
+    det_postprocess,
     fai_detections_to_sv,
+    get_postprocess_fn,
     image_loader,
     image_preprocess,
     index_to_class,
-    mask_to_xyxy,
+    instance_postprocess,
+    masks_to_xyxy,
     scale_detections,
     scale_mask,
+    semseg_postprocess,
     sv_to_fai_detections,
 )
 
@@ -180,28 +184,144 @@ def test_sv_to_focoos_detections(sv_detections: sv.Detections):
     assert isinstance(result_focoos_detection.mask, str), "Mask should be a string"
 
 
-def test_mask_to_xyxy():
+def test_masks_to_xyxy():
     # Basic case: a single mask with one active pixel
     mask1 = np.zeros((1, 5, 5), dtype=bool)
     mask1[0, 2, 3] = True  # One active pixel at (2,3)
-    assert np.array_equal(mask_to_xyxy(mask1), np.array([[3, 2, 3, 2]]))
+    assert np.array_equal(masks_to_xyxy(mask1), np.array([[3, 2, 3, 2]]))
 
     # Case with a rectangle
     mask2 = np.zeros((1, 5, 5), dtype=bool)
     mask2[0, 1:4, 2:5] = True  # Rectangle between (1,2) and (3,4)
-    assert np.array_equal(mask_to_xyxy(mask2), np.array([[2, 1, 4, 3]]))
+    assert np.array_equal(masks_to_xyxy(mask2), np.array([[2, 1, 4, 3]]))
 
     # Case with multiple masks
     masks = np.zeros((2, 5, 5), dtype=bool)
     masks[0, 1:4, 2:5] = True  # First rectangle
     masks[1, 0:3, 1:4] = True  # Second rectangle
     expected = np.array([[2, 1, 4, 3], [1, 0, 3, 2]])
-    assert np.array_equal(mask_to_xyxy(masks), expected)
-
-    # Case with an empty mask
-    empty_mask = np.zeros((1, 5, 5), dtype=bool)
-    assert np.array_equal(mask_to_xyxy(empty_mask), np.array([[0, 0, 0, 0]]))
+    assert np.array_equal(masks_to_xyxy(masks), expected)
 
     # Case with a mask covering the entire image
     full_mask = np.ones((1, 5, 5), dtype=bool)
-    assert np.array_equal(mask_to_xyxy(full_mask), np.array([[0, 0, 4, 4]]))
+    assert np.array_equal(masks_to_xyxy(full_mask), np.array([[0, 0, 4, 4]]))
+
+
+def test_det_post_process():
+    cls_ids = np.array([1, 2, 3])
+    boxes = np.array([[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8], [0.9, 1.0, 1.1, 1.2]])
+    confs = np.array([0.8, 0.9, 0.7])
+    out = [cls_ids, boxes, confs]
+
+    im0_shape = (640, 480)
+    conf_threshold = 0.75
+    sv_detections = det_postprocess(out, im0_shape, conf_threshold)
+
+    np.testing.assert_array_equal(sv_detections.xyxy, np.array([[48, 128, 144, 256], [240, 384, 336, 512]]))
+    assert sv_detections.class_id is not None
+    np.testing.assert_array_equal(sv_detections.class_id, np.array([1, 2]))
+    assert sv_detections.confidence is not None
+    np.testing.assert_array_equal(sv_detections.confidence, np.array([0.8, 0.9]))
+
+
+def test_semseg_postprocess():
+    cls_ids = np.array([1, 2, 3])
+    mask = np.array(
+        [
+            [0, 1, 1, 2],
+            [0, 1, 2, 2],
+            [0, 0, 1, 2],
+        ]
+    )
+    confs = np.array([0.7, 0.9, 0.8])
+    out = [
+        np.expand_dims(cls_ids, axis=0),
+        np.expand_dims(mask, axis=0),
+        np.expand_dims(confs, axis=0),
+    ]
+
+    im0_shape = (3, 4)
+    conf_threshold = 0.75
+
+    sv_detections = semseg_postprocess(out, im0_shape, conf_threshold)
+
+    # Expected masks
+    expected_masks = np.array(
+        [
+            [
+                [False, True, True, False],
+                [False, True, False, False],
+                [False, False, True, False],
+            ],  # Class 1
+            [
+                [False, False, False, True],
+                [False, False, True, True],
+                [False, False, False, True],
+            ],  # Class 2
+        ]
+    )
+
+    # Assertions
+    assert sv_detections.mask is not None
+    np.testing.assert_array_equal(sv_detections.mask, expected_masks)
+    assert sv_detections.class_id is not None
+    np.testing.assert_array_equal(sv_detections.class_id, np.array([2, 3]))
+    assert sv_detections.confidence is not None
+    np.testing.assert_array_equal(sv_detections.confidence, np.array([0.9, 0.8]))
+    assert sv_detections.xyxy.shape == (2, 4)
+
+
+def test_get_postprocess_fn():
+    """
+    Test the get_postprocess_fn function to ensure it returns
+    the correct postprocessing function for each task.
+    """
+    # Test detection task
+    det_fn = get_postprocess_fn(FocoosTask.DETECTION)
+    assert det_fn == det_postprocess, "Detection task should return det_postprocess function"
+
+    # Test instance segmentation task
+    instance_fn = get_postprocess_fn(FocoosTask.INSTANCE_SEGMENTATION)
+    assert instance_fn == instance_postprocess, "Instance segmentation task should return instance_postprocess function"
+
+    # Test semantic segmentation task
+    semseg_fn = get_postprocess_fn(FocoosTask.SEMSEG)
+    assert semseg_fn == semseg_postprocess, "Semantic segmentation task should return semseg_postprocess function"
+
+    # Test all FocoosTask values to ensure no exceptions
+    for task in FocoosTask:
+        fn = get_postprocess_fn(task)
+        assert callable(fn), f"Postprocess function for {task} should be callable"
+
+
+def test_instance_postprocess():
+    """Test instance segmentation postprocessing"""
+    cls_ids = np.array([0, 1])
+    masks = np.zeros((2, 100, 100))
+    masks[0, 10:30, 10:30] = 1
+    masks[1, 40:60, 40:60] = 1
+    confs = np.array([0.95, 0.85])
+    out = [[cls_ids], [masks], [confs]]
+
+    result = instance_postprocess(out, (100, 100), 0.8)
+
+    assert isinstance(result, sv.Detections)
+    assert len(result) == 2
+    assert result.mask is not None
+    assert result.xyxy is not None
+    assert result.class_id is not None
+    assert result.confidence is not None
+
+
+def test_confidence_threshold_filtering():
+    """Test that confidence threshold filtering works correctly"""
+    out = [
+        np.array([0, 1, 2]),  # cls_ids
+        np.array([[0.1, 0.1, 0.3, 0.3], [0.4, 0.4, 0.6, 0.6], [0.7, 0.7, 0.9, 0.9]]),  # boxes
+        np.array([0.95, 0.55, 0.85]),  # confs
+    ]
+
+    result = det_postprocess(out, (100, 100), conf_threshold=0.8)
+
+    assert len(result) == 2  # Should only keep detections with conf > 0.8
+    assert all(conf > 0.8 for conf in result.confidence)


### PR DESCRIPTION


- Move postprocessing functions from runtime.py to utils/vision.py
- Update runtime classes to return raw model outputs
- Modify local and remote model classes to apply postprocessing separately
- Improve logging with more detailed inference time and detection count information
- Enhance error handling for cases with no detections (empty masks)


## Context
New segmentation postprocess is broken when there are empty masks (non_null_pixel =0 or mask.shape !=2) in model output.