### PR TITLE
fix(README.md): fix spelling in Python sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ im = "https://public.focoos.ai/samples/motogp.jpg" # can be local/remote path, n
 
 model = ModelManager.get("fai-detr-l-obj365") # any models from ModelRegistry, FocoosHub or local folder
 
-detections = model.infer(im,annotate=true)
+detections = model.infer(im,annotate=True)
 
 ```
 


### PR DESCRIPTION
Fix a trivial typo in the Python sample code shown in section "Quickstart" of toplevel README.md